### PR TITLE
Feature/sprint 2 node double click event

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -17,6 +17,68 @@
    <property name="enabled">
     <bool>true</bool>
    </property>
+   <widget class="QComboBox" name="scaleCombo">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>60</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimumSize">
+     <size>
+      <width>60</width>
+      <height>0</height>
+     </size>
+    </property>
+    <property name="currentText">
+     <string>100</string>
+    </property>
+    <item>
+     <property name="text">
+      <string>50</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>75</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>100</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>125</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>150</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>200</string>
+     </property>
+    </item>
+   </widget>
+   <widget class="QLabel" name="percentLabel">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>40</y>
+      <width>16</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>%</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -15,85 +15,109 @@ PropertyTab::~PropertyTab()
     delete ui;
 }
 
-void PropertyTab::on_fontComboBox_currentFontChanged(const QFont &f)//글꼴
+void PropertyTab::on_fontBox_currentFontChanged(const QFont &f)//글꼴
 {
-   // focusedNode= map->searchFocusInNode(map->getRoot());  //focused 된 라벨의 주소를 받아왔다 치자
-  //  *focusedNode = map->getRoot()->label();
-    focusedNode->setFont(ui->fontBox->currentFont());
+
+   NodeWidget* root= map->searchFocusInNode(map->getRoot());
+   focusedNode = root->labelPointer();//focused 된 라벨의 주소를 받아왔다 치자
+   QFont font = ui->fontBox->currentFont();
+   QFont fontOfNode = focusedNode->font();
+   if(fontOfNode.bold()) font.setBold(true);
+   if(fontOfNode.italic()) font.setItalic(true);
+   font.setPointSize(fontOfNode.pointSize());
+   focusedNode->setFont(font);
+   showAllProperty();
 }
 
 void PropertyTab::on_buttonBold_clicked()//굵기
 {
-     NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+     focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
      QFont font = focusedNode->font();
      if(font.bold())//만약 이미 굵은 상태
-        font.setBold(true);
+        font.setBold(false);
      else
-         font.setBold(false);
+         font.setBold(true);
      focusedNode->setFont(font);
+     showAllProperty();
 }
 
 void PropertyTab::on_buttonItalic_clicked()//기울임
 {
-    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
     QFont font = focusedNode->font();
     if(font.italic())//만약 이미 기울어진 상태
-       font.setItalic(true);
+       font.setItalic(false);
     else
-        font.setItalic(false);
+        font.setItalic(true);
     focusedNode->setFont(font);
+     showAllProperty();
 }
 
 void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
 {
-    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
     QFont font = focusedNode->font();
     font.setPointSize(ui->contentSizeBox->value());
     focusedNode->setFont(font);
+    showAllProperty();
 }
 
 
 
 void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 {
-    NodeLabel* focusedNode = new NodeLabel();
-    focusedNode->setStyleSheet("border : solid 20px black;");
-    focusedNode->setNodeShape(rec);
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
+    if(focusedNode->getNodeShape()==rec){
+        focusedNode->setStyleSheet("border-width: none");
+        focusedNode->setNodeShape(nothing);
+    }
+    else{focusedNode->setStyleSheet("border-width: 2px;"
+                               "border-style : solid;"
+                               "border-color: black;");
+        focusedNode->setNodeShape(rec);}
+    showAllProperty();
 }
 
 void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 {
-    NodeLabel* focusedNode = new NodeLabel();
-    focusedNode->setStyleSheet("border-width: 2px;"
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
+    if(focusedNode->getNodeShape()==roundRec){
+        focusedNode->setStyleSheet("border-width: none;");
+        focusedNode->setNodeShape(nothing);
+    }else{focusedNode->setStyleSheet("border-width: 2px;"
                                "border-style : solid;"
                                "border-radius: 4px;"
                                "border-color: black;");
-    focusedNode->setNodeShape(roundRec);
+    focusedNode->setNodeShape(roundRec);}
+     showAllProperty();
 }
 
-void PropertyTab::on_ovalButton_clicked()//노드 모양 타원 ***** painter사용 요망
-{
-    NodeLabel* focusedNode = new NodeLabel();
-    focusedNode->setStyleSheet("border-width: 2px;"
-                               "border-style : solid;"
-                               "border-radius: 4px;"
-                               "border-color: black;");
-    focusedNode->setNodeShape(oval);
-}
 
 void PropertyTab::on_underlineButton_clicked()//노드 모양 밑줄
 {
-    NodeLabel* focusedNode = new NodeLabel();
-    focusedNode->setStyleSheet("border-top-style: none;"
+    qDebug()<<"눌림";
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
+    if(focusedNode->getNodeShape()==underline){
+        focusedNode->setStyleSheet("border-width: none;");
+        focusedNode->setNodeShape(nothing);
+    }else{focusedNode->setStyleSheet("border-top-style: none;"
                                "border-right-style: none;"
                                "border-bottom-style: solid;"
                                "border-left-style: none;"
                                "border-width: 2px;border-color: black;");
-    focusedNode->setNodeShape(underline);
+    focusedNode->setNodeShape(underline);}
+    showAllProperty();
 }
 
 void PropertyTab::showAllProperty(){
-    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
     QFont font = focusedNode->font();
     QFont boldFont;
     boldFont.setBold(true);
@@ -114,6 +138,8 @@ void PropertyTab::showAllProperty(){
         ui->roundRecButton->setFont(boldFont); break;
     case underline:
         ui->underlineButton->setFont(boldFont); break;
+    default :
+        break;
     }
 }
 void PropertyTab::setDockWedigetDefault(){

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -22,7 +22,7 @@ PropertyTab::~PropertyTab()
 void PropertyTab::on_fontBox_currentFontChanged(const QFont &f)//글꼴
 {
 
-   NodeWidget* root= map->searchFocusInNode(map->getRoot());
+   NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
    if(root==nullptr)
        return;
    focusedNode = root->labelPointer();//focused 된 라벨의 주소를 받아왔다 치자
@@ -38,7 +38,7 @@ void PropertyTab::on_fontBox_currentFontChanged(const QFont &f)//글꼴
 
 void PropertyTab::on_buttonBold_clicked()//굵기
 {
-     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+     NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
      if(root==nullptr)
          return;
      focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
@@ -54,7 +54,7 @@ void PropertyTab::on_buttonBold_clicked()//굵기
 
 void PropertyTab::on_buttonItalic_clicked()//기울임
 {
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
@@ -70,7 +70,7 @@ void PropertyTab::on_buttonItalic_clicked()//기울임
 
 void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
 {
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();
@@ -85,7 +85,7 @@ void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
 
 void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 {
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();
@@ -103,7 +103,7 @@ void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 
 void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 {
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();
@@ -121,7 +121,7 @@ void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 
 void PropertyTab::on_underlineButton_clicked()//노드 모양 밑줄
 {
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();
@@ -143,7 +143,7 @@ void PropertyTab::on_buttonColor_clicked(){//글자색 입력받는 슬롯
 }
 
 void PropertyTab::changeTextOfColor(){//글자 색 바꾸는 슬롯
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();
@@ -168,7 +168,7 @@ void PropertyTab::changeTextOfColor(){//글자 색 바꾸는 슬롯
 }
 
 void PropertyTab::showAllProperty(){//node의 속성 dockWidget에 보여주기
-    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    NodeWidget* root= NodeWidget::searchFocusInNode(map->getRoot());
     if(root==nullptr)
         return;
     focusedNode = root->labelPointer();

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -1,0 +1,127 @@
+#include "propertytab.h"
+#include "ui_propertytab.h"
+#include "headers/nodewidget.h"
+#include <QDebug>
+
+PropertyTab::PropertyTab(QWidget *parent) :
+    QDockWidget(parent),
+    ui(new Ui::PropertyTab)
+{
+    ui->setupUi(this);
+}
+
+PropertyTab::~PropertyTab()
+{
+    delete ui;
+}
+
+void PropertyTab::on_fontComboBox_currentFontChanged(const QFont &f)//글꼴
+{
+   // focusedNode= map->searchFocusInNode(map->getRoot());  //focused 된 라벨의 주소를 받아왔다 치자
+  //  *focusedNode = map->getRoot()->label();
+    focusedNode->setFont(ui->fontBox->currentFont());
+}
+
+void PropertyTab::on_buttonBold_clicked()//굵기
+{
+     NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+     QFont font = focusedNode->font();
+     if(font.bold())//만약 이미 굵은 상태
+        font.setBold(true);
+     else
+         font.setBold(false);
+     focusedNode->setFont(font);
+}
+
+void PropertyTab::on_buttonItalic_clicked()//기울임
+{
+    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    QFont font = focusedNode->font();
+    if(font.italic())//만약 이미 기울어진 상태
+       font.setItalic(true);
+    else
+        font.setItalic(false);
+    focusedNode->setFont(font);
+}
+
+void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
+{
+    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    QFont font = focusedNode->font();
+    font.setPointSize(ui->contentSizeBox->value());
+    focusedNode->setFont(font);
+}
+
+
+
+void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
+{
+    NodeLabel* focusedNode = new NodeLabel();
+    focusedNode->setStyleSheet("border : solid 20px black;");
+    focusedNode->setNodeShape(rec);
+}
+
+void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
+{
+    NodeLabel* focusedNode = new NodeLabel();
+    focusedNode->setStyleSheet("border-width: 2px;"
+                               "border-style : solid;"
+                               "border-radius: 4px;"
+                               "border-color: black;");
+    focusedNode->setNodeShape(roundRec);
+}
+
+void PropertyTab::on_ovalButton_clicked()//노드 모양 타원 ***** painter사용 요망
+{
+    NodeLabel* focusedNode = new NodeLabel();
+    focusedNode->setStyleSheet("border-width: 2px;"
+                               "border-style : solid;"
+                               "border-radius: 4px;"
+                               "border-color: black;");
+    focusedNode->setNodeShape(oval);
+}
+
+void PropertyTab::on_underlineButton_clicked()//노드 모양 밑줄
+{
+    NodeLabel* focusedNode = new NodeLabel();
+    focusedNode->setStyleSheet("border-top-style: none;"
+                               "border-right-style: none;"
+                               "border-bottom-style: solid;"
+                               "border-left-style: none;"
+                               "border-width: 2px;border-color: black;");
+    focusedNode->setNodeShape(underline);
+}
+
+void PropertyTab::showAllProperty(){
+    NodeLabel* focusedNode = new NodeLabel();  //focused 된 라벨의 주소를 받아왔다 치자
+    QFont font = focusedNode->font();
+    QFont boldFont;
+    boldFont.setBold(true);
+    setDockWedigetDefault();
+
+    if(font.bold())//굵기
+        ui->buttonBold->setFont(boldFont);
+
+    if(font.italic())//기울임
+        ui->buttonItalic->setFont(boldFont);
+
+    ui->contentSizeBox->setValue(font.pointSize()); //글씨크기
+    ui->fontBox->setCurrentText(font.toString()); //글꼴
+    switch(focusedNode->getNodeShape()){
+    case rec:
+        ui->rectangleButton->setFont(boldFont); break;
+    case roundRec:
+        ui->roundRecButton->setFont(boldFont); break;
+    case underline:
+        ui->underlineButton->setFont(boldFont); break;
+    }
+}
+void PropertyTab::setDockWedigetDefault(){
+    QFont notBoldFont;
+    notBoldFont.setBold(false);
+    ui->buttonBold->setFont(notBoldFont);
+    ui->buttonItalic->setFont(notBoldFont);
+    ui->rectangleButton->setFont(notBoldFont);
+    ui->roundRecButton->setFont(notBoldFont);
+    ui->underlineButton->setFont(notBoldFont);
+}

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -205,3 +205,7 @@ void PropertyTab::setDockWedigetDefault(){//dockWidget속성 초기화
     ui->roundRecButton->setFont(notBoldFont);
     ui->underlineButton->setFont(notBoldFont);
 }
+
+QTextEdit* PropertyTab::getTextEdit() {
+    return ui->textEdit;
+}

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -2,12 +2,16 @@
 #include "ui_propertytab.h"
 #include "headers/nodewidget.h"
 #include <QDebug>
+#include <QColorDialog>
 
 PropertyTab::PropertyTab(QWidget *parent) :
     QDockWidget(parent),
     ui(new Ui::PropertyTab)
 {
+
+    //QObject::connect(colorDial,SIGNAL(colorSelected(QColor)),this,SLOT(changeTextOfColor()));
     ui->setupUi(this);
+
 }
 
 PropertyTab::~PropertyTab()
@@ -71,14 +75,15 @@ void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
     focusedNode = root->labelPointer();
+    QString textColor = "color :" +focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==rec){
-        focusedNode->setStyleSheet("border-width: none");
+        focusedNode->setStyleSheet(nothingCSS+textColor);
         focusedNode->setNodeShape(nothing);
     }
-    else{focusedNode->setStyleSheet("border-width: 2px;"
-                               "border-style : solid;"
-                               "border-color: black;");
-        focusedNode->setNodeShape(rec);}
+    else{
+        focusedNode->setStyleSheet(recCSS+textColor);
+        focusedNode->setNodeShape(rec);
+    }
     showAllProperty();
 }
 
@@ -86,36 +91,62 @@ void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
     focusedNode = root->labelPointer();
+    QString textColor = "color :" +focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==roundRec){
-        focusedNode->setStyleSheet("border-width: none;");
+        focusedNode->setStyleSheet(nothingCSS+textColor);
         focusedNode->setNodeShape(nothing);
-    }else{focusedNode->setStyleSheet("border-width: 2px;"
-                               "border-style : solid;"
-                               "border-radius: 4px;"
-                               "border-color: black;");
-    focusedNode->setNodeShape(roundRec);}
+    }else{
+        focusedNode->setStyleSheet(roundRecCSS+textColor);
+        focusedNode->setNodeShape(roundRec);
+    }
      showAllProperty();
 }
 
 
 void PropertyTab::on_underlineButton_clicked()//노드 모양 밑줄
 {
-    qDebug()<<"눌림";
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
     focusedNode = root->labelPointer();
+    QString textColor = "color :" + focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==underline){
-        focusedNode->setStyleSheet("border-width: none;");
+        focusedNode->setStyleSheet(nothingCSS+textColor);
         focusedNode->setNodeShape(nothing);
-    }else{focusedNode->setStyleSheet("border-top-style: none;"
-                               "border-right-style: none;"
-                               "border-bottom-style: solid;"
-                               "border-left-style: none;"
-                               "border-width: 2px;border-color: black;");
-    focusedNode->setNodeShape(underline);}
+    }else{
+        focusedNode->setStyleSheet(underlineCSS+textColor);
+        focusedNode->setNodeShape(underline);
+    }
     showAllProperty();
 }
 
-void PropertyTab::showAllProperty(){
+void PropertyTab::on_buttonColor_clicked(){//글자색 입력받는 슬롯
+    colorDial = new QColorDialog();
+    colorDial->show();
+    QObject::connect(colorDial,SIGNAL(colorSelected(QColor)),this,SLOT(changeTextOfColor()));
+}
+
+void PropertyTab::changeTextOfColor(){//글자 색 바꾸는 슬롯
+    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    focusedNode = root->labelPointer();
+    focusedNode->setNodeTextColor(colorDial->selectedColor());
+    QString textColor = "color :"+focusedNode->getNodeTextColor();
+    QString shape;
+    int sh=-1;
+    sh = focusedNode->getNodeShape();
+    switch(sh){
+    case rec:
+        shape = recCSS; break;
+    case roundRec:
+        shape = roundRecCSS; break;
+    case underline:
+        shape = underlineCSS; break;
+    default:
+        shape = nothingCSS; break;
+    }
+    focusedNode->setStyleSheet(shape + textColor);
+    showAllProperty();
+}
+
+void PropertyTab::showAllProperty(){//node의 속성 dockWidget에 보여주기
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
     focusedNode = root->labelPointer();
     QFont font = focusedNode->font();
@@ -142,7 +173,7 @@ void PropertyTab::showAllProperty(){
         break;
     }
 }
-void PropertyTab::setDockWedigetDefault(){
+void PropertyTab::setDockWedigetDefault(){//dockWidget속성 초기화
     QFont notBoldFont;
     notBoldFont.setBold(false);
     ui->buttonBold->setFont(notBoldFont);

--- a/forms/propertytab.cpp
+++ b/forms/propertytab.cpp
@@ -23,6 +23,8 @@ void PropertyTab::on_fontBox_currentFontChanged(const QFont &f)//글꼴
 {
 
    NodeWidget* root= map->searchFocusInNode(map->getRoot());
+   if(root==nullptr)
+       return;
    focusedNode = root->labelPointer();//focused 된 라벨의 주소를 받아왔다 치자
    QFont font = ui->fontBox->currentFont();
    QFont fontOfNode = focusedNode->font();
@@ -30,12 +32,15 @@ void PropertyTab::on_fontBox_currentFontChanged(const QFont &f)//글꼴
    if(fontOfNode.italic()) font.setItalic(true);
    font.setPointSize(fontOfNode.pointSize());
    focusedNode->setFont(font);
+   root->setEditFont(font);
    showAllProperty();
 }
 
 void PropertyTab::on_buttonBold_clicked()//굵기
 {
      NodeWidget* root= map->searchFocusInNode(map->getRoot());
+     if(root==nullptr)
+         return;
      focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
      QFont font = focusedNode->font();
      if(font.bold())//만약 이미 굵은 상태
@@ -43,12 +48,15 @@ void PropertyTab::on_buttonBold_clicked()//굵기
      else
          font.setBold(true);
      focusedNode->setFont(font);
+     root->setEditFont(font);
      showAllProperty();
 }
 
 void PropertyTab::on_buttonItalic_clicked()//기울임
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer(); //focused 된 라벨의 주소를 받아왔다 치자
     QFont font = focusedNode->font();
     if(font.italic())//만약 이미 기울어진 상태
@@ -56,16 +64,20 @@ void PropertyTab::on_buttonItalic_clicked()//기울임
     else
         font.setItalic(true);
     focusedNode->setFont(font);
+    root->setEditFont(font);
      showAllProperty();
 }
 
 void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     QFont font = focusedNode->font();
     font.setPointSize(ui->contentSizeBox->value());
     focusedNode->setFont(font);
+    root->setEditFont(font);
     showAllProperty();
 }
 
@@ -74,6 +86,8 @@ void PropertyTab::on_contentSizeBox_valueChanged(int arg1)//글씨크기
 void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     QString textColor = "color :" +focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==rec){
@@ -90,6 +104,8 @@ void PropertyTab::on_rectangleButton_clicked()//노드 모양 네모
 void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     QString textColor = "color :" +focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==roundRec){
@@ -106,6 +122,8 @@ void PropertyTab::on_roundRecButton_clicked()//노드 모양 둥근 네모
 void PropertyTab::on_underlineButton_clicked()//노드 모양 밑줄
 {
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     QString textColor = "color :" + focusedNode->getNodeTextColor();
     if(focusedNode->getNodeShape()==underline){
@@ -126,6 +144,8 @@ void PropertyTab::on_buttonColor_clicked(){//글자색 입력받는 슬롯
 
 void PropertyTab::changeTextOfColor(){//글자 색 바꾸는 슬롯
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     focusedNode->setNodeTextColor(colorDial->selectedColor());
     QString textColor = "color :"+focusedNode->getNodeTextColor();
@@ -143,11 +163,14 @@ void PropertyTab::changeTextOfColor(){//글자 색 바꾸는 슬롯
         shape = nothingCSS; break;
     }
     focusedNode->setStyleSheet(shape + textColor);
+
     showAllProperty();
 }
 
 void PropertyTab::showAllProperty(){//node의 속성 dockWidget에 보여주기
     NodeWidget* root= map->searchFocusInNode(map->getRoot());
+    if(root==nullptr)
+        return;
     focusedNode = root->labelPointer();
     QFont font = focusedNode->font();
     QFont boldFont;

--- a/forms/propertytab.h
+++ b/forms/propertytab.h
@@ -11,7 +11,7 @@ class PropertyTab;
 class PropertyTab : public QDockWidget
 {
     Q_OBJECT
-enum nodeShape{rec,oval,underline,roundRec};
+enum nodeShape{nothing,rec,underline,roundRec};
 public:
     explicit PropertyTab(QWidget *parent = 0);
     ~PropertyTab();
@@ -20,23 +20,19 @@ public:
     void setNodeWidget(NodeWidget * map){this->map = map;}
 
 private slots:
-    //void on_fontComboBox_activated(const QString &arg1);
+   // void on_fontComboBox_activated(const QString &arg1);
 
-    void on_fontComboBox_currentFontChanged(const QFont &f);
+    void on_fontBox_currentFontChanged(const QFont &f);
 
     void on_buttonBold_clicked();
 
     void on_buttonItalic_clicked();
-
-    //void on_spinBox_valueChanged(int arg1);
 
     void on_contentSizeBox_valueChanged(int arg1);
 
     void on_rectangleButton_clicked();
 
     void on_roundRecButton_clicked();
-
-    void on_ovalButton_clicked();
 
     void on_underlineButton_clicked();
 

--- a/forms/propertytab.h
+++ b/forms/propertytab.h
@@ -2,6 +2,8 @@
 #define PROPERTYTAB_H
 
 #include <QDockWidget>
+#include <QColorDialog>
+#include <QString>
 #include "headers/nodewidget.h"
 
 namespace Ui {
@@ -19,9 +21,9 @@ public:
     void setDockWedigetDefault(); //dockWidget의 값을 초기화 한다.
     void setNodeWidget(NodeWidget * map){this->map = map;}
 
-private slots:
-   // void on_fontComboBox_activated(const QString &arg1);
 
+private slots:
+ //ui에 있는 속성들이 각각 눌렸을 때
     void on_fontBox_currentFontChanged(const QFont &f);
 
     void on_buttonBold_clicked();
@@ -36,10 +38,19 @@ private slots:
 
     void on_underlineButton_clicked();
 
+    void on_buttonColor_clicked();
+
+    void changeTextOfColor();
+
 private:
     Ui::PropertyTab *ui;
     NodeWidget * map;
     NodeLabel* focusedNode;
+    QColorDialog *colorDial;
+    QString underlineCSS =  "border-top-style: none; border-right-style: none; border-bottom-style: solid; border-left-style: none; border-width: 2px;border-color: black;";
+    QString recCSS = "border-width: 2px;border-style : solid;border-color: black;";
+    QString roundRecCSS = "border-width: 2px; border-style : solid; border-radius: 4px; border-color: black;";
+    QString nothingCSS = "border: 2px solid gray;";
 };
 
 #endif // PROPERTYTAB_H

--- a/forms/propertytab.h
+++ b/forms/propertytab.h
@@ -1,0 +1,49 @@
+#ifndef PROPERTYTAB_H
+#define PROPERTYTAB_H
+
+#include <QDockWidget>
+#include "headers/nodewidget.h"
+
+namespace Ui {
+class PropertyTab;
+}
+
+class PropertyTab : public QDockWidget
+{
+    Q_OBJECT
+enum nodeShape{rec,oval,underline,roundRec};
+public:
+    explicit PropertyTab(QWidget *parent = 0);
+    ~PropertyTab();
+    void showAllProperty(); //node가 가지고 있는 속성을 dockWidget에 표현한다.
+    void setDockWedigetDefault(); //dockWidget의 값을 초기화 한다.
+    void setNodeWidget(NodeWidget * map){this->map = map;}
+
+private slots:
+    void on_fontComboBox_activated(const QString &arg1);
+
+    void on_fontComboBox_currentFontChanged(const QFont &f);
+
+    void on_buttonBold_clicked();
+
+    void on_buttonItalic_clicked();
+
+    void on_spinBox_valueChanged(int arg1);
+
+    void on_contentSizeBox_valueChanged(int arg1);
+
+    void on_rectangleButton_clicked();
+
+    void on_roundRecButton_clicked();
+
+    void on_ovalButton_clicked();
+
+    void on_underlineButton_clicked();
+
+private:
+    Ui::PropertyTab *ui;
+    NodeWidget * map;
+    NodeLabel* focusedNode;
+};
+
+#endif // PROPERTYTAB_H

--- a/forms/propertytab.h
+++ b/forms/propertytab.h
@@ -20,7 +20,7 @@ public:
     void setNodeWidget(NodeWidget * map){this->map = map;}
 
 private slots:
-    void on_fontComboBox_activated(const QString &arg1);
+    //void on_fontComboBox_activated(const QString &arg1);
 
     void on_fontComboBox_currentFontChanged(const QFont &f);
 
@@ -28,7 +28,7 @@ private slots:
 
     void on_buttonItalic_clicked();
 
-    void on_spinBox_valueChanged(int arg1);
+    //void on_spinBox_valueChanged(int arg1);
 
     void on_contentSizeBox_valueChanged(int arg1);
 

--- a/forms/propertytab.h
+++ b/forms/propertytab.h
@@ -20,7 +20,7 @@ public:
     void showAllProperty(); //node가 가지고 있는 속성을 dockWidget에 표현한다.
     void setDockWedigetDefault(); //dockWidget의 값을 초기화 한다.
     void setNodeWidget(NodeWidget * map){this->map = map;}
-
+    QTextEdit* getTextEdit();
 
 private slots:
  //ui에 있는 속성들이 각각 눌렸을 때

--- a/forms/propertytab.ui
+++ b/forms/propertytab.ui
@@ -51,7 +51,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="styleTab">
        <property name="sizePolicy">

--- a/forms/propertytab.ui
+++ b/forms/propertytab.ui
@@ -214,13 +214,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="ovalButton">
-              <property name="text">
-               <string>타원</string>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QPushButton" name="underlineButton">
               <property name="text">
                <string>밑줄</string>

--- a/forms/propertytab.ui
+++ b/forms/propertytab.ui
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PropertyTab</class>
+ <widget class="QDockWidget" name="PropertyTab">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>322</width>
+    <height>578</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>322</width>
+    <height>377</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>PropertyTab</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_6">
+    <item>
+     <widget class="QTabWidget" name="tabWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>300</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="styleTab">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <attribute name="title">
+        <string>Tab 1</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>7</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="rightMargin">
+         <number>11</number>
+        </property>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="bottomMargin">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="baseSize">
+             <size>
+              <width>0</width>
+              <height>15</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Text Style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFontComboBox" name="fontBox"/>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QPushButton" name="buttonBold">
+              <property name="text">
+               <string>Bold</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonColor">
+              <property name="text">
+               <string>Color</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonItalic">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Italic</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="maximumSize">
+               <size>
+                <width>50</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Size</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="contentSizeBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="bottomMargin">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Node Style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QPushButton" name="rectangleButton">
+              <property name="text">
+               <string>네모</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="roundRecButton">
+              <property name="text">
+               <string>둥근네모</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="ovalButton">
+              <property name="text">
+               <string>타원</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="underlineButton">
+              <property name="text">
+               <string>밑줄</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="Line" name="line_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Edge Style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QComboBox" name="comboBox"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_10">
+              <property name="text">
+               <string>Color</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_9">
+              <property name="text">
+               <string>PushButton</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="textTab">
+       <attribute name="title">
+        <string>Tab 2</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QTextEdit" name="textEdit"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/forms/propertytab.ui
+++ b/forms/propertytab.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>322</width>
-    <height>578</height>
+    <height>377</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
      <horstretch>0</horstretch>
      <verstretch>0</verstretch>
     </sizepolicy>

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -13,8 +13,6 @@
 #include <QKeyEvent>
 #include <QDebug>
 #include "headers/mindmapview.h"
-#include "headers/nodewidget.h"
-#include "headers/parsing.h"
 #include "forms/propertytab.h"
 
 namespace Ui {
@@ -31,6 +29,7 @@ public:
     void showStartscreen();
     MindmapView* getMapScreen(){return mapScreen;}
     NodeWidget* getMap(){return map;}
+    Process* getProcess(){return process;}
 
 public slots:
     //slots for graphic & drawing
@@ -45,6 +44,8 @@ public slots:
 
     //handle changed content at quit
     void quit();
+
+    void addProcess(NodeWidget*, CommandType);
 
 private:
     void setFileMenuToolbar();
@@ -69,6 +70,8 @@ private:
     QAction *actionSave;
     QAction *actionSaveAs;
     QAction *actionQuit;
+
+    Process* process;
 };
 
 #endif // MAINWINDOW_H

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -10,6 +10,8 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QTextStream>
+#include <QKeyEvent>
+#include <QDebug>
 #include "headers/mindmapview.h"
 #include "headers/nodewidget.h"
 #include "headers/parsing.h"
@@ -23,13 +25,15 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
+    explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
     void showStartscreen();
+    MindmapView* getMapScreen(){return mapScreen;}
 
 public slots:
     //slots for graphic & drawing
     void reload();
+    void renewTextEdit();
 
     // filemenu actions
     void newFile();

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -30,6 +30,7 @@ public:
     ~MainWindow();
     void showStartscreen();
     MindmapView* getMapScreen(){return mapScreen;}
+    NodeWidget* getMap(){return map;}
 
 public slots:
     //slots for graphic & drawing

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -15,6 +15,7 @@
 #include "headers/mindmapview.h"
 #include "headers/nodewidget.h"
 #include "headers/parsing.h"
+#include "forms/propertytab.h"
 
 namespace Ui {
 class MainWindow;
@@ -54,6 +55,7 @@ private:
     //widget & graphic component
     MindmapView* mapScreen;
     NodeWidget* map;
+    PropertyTab * dockWidget;
     QTextEdit* edit;
     QPushButton* redrawButton;
     QHBoxLayout* layout;

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -11,6 +11,7 @@
 #include <QFileDialog>
 #include <QTextStream>
 #include <QKeyEvent>
+#include <QComboBox>
 #include <QDebug>
 #include "headers/mindmapview.h"
 #include "forms/propertytab.h"
@@ -48,6 +49,13 @@ public slots:
     void addProcess(NodeWidget*, CommandType);
     void addProcess(NodeWidget*, NodeWidget*, CommandType);
 
+private slots:
+    void on_scaleCombo_currentIndexChanged(const QString& arg1);
+    void scaleCombo_setCurrentScale();
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
+
 private:
     void setFileMenuToolbar();
 
@@ -61,7 +69,6 @@ private:
     PropertyTab * dockWidget;
     QTextEdit* edit;
     QPushButton* redrawButton;
-    QHBoxLayout* layout;
     QVBoxLayout* rightLayout;
 
     // FileMenu Toolbar actions
@@ -73,6 +80,13 @@ private:
     QAction *actionQuit;
 
     Process* process;
+
+    QVBoxLayout* layout;
+    QHBoxLayout* programLayout;
+    QHBoxLayout* scaleComboLayout;
+    QComboBox* scaleCombo;
+    QLabel* percentLabel;
+
 };
 
 #endif // MAINWINDOW_H

--- a/headers/mainwindow.h
+++ b/headers/mainwindow.h
@@ -46,6 +46,7 @@ public slots:
     void quit();
 
     void addProcess(NodeWidget*, CommandType);
+    void addProcess(NodeWidget*, NodeWidget*, CommandType);
 
 private:
     void setFileMenuToolbar();

--- a/headers/mindmapview.h
+++ b/headers/mindmapview.h
@@ -6,16 +6,16 @@
 #include <QGraphicsSceneMouseEvent>
 #include "headers/nodewidget.h"
 
+class MainWindow;
+
 class MindmapView : public QGraphicsView{
     Q_OBJECT
 
 public:
-    MindmapView(){
-        mindmapScene = new QGraphicsScene();
-        this->setScene(mindmapScene);
-        setDragMode(QGraphicsView::ScrollHandDrag);
-    }
+    MindmapView();
     QGraphicsScene* mindmapScene;
+    MainWindow* mainWindow;
+
 public slots:
 
     void zoomIn(){
@@ -32,13 +32,7 @@ protected:
     void wheelEvent(QWheelEvent *event){
         event->delta() > 0 ? zoomIn() : zoomOut();
     }
-    void mousePressEvent(QMouseEvent *e){
-        if(e->button() == Qt::RightButton){
-            this->setFocus();
-            emit viewClicked();
-        }
-        QGraphicsView::mousePressEvent(e);
-    }
+    void mousePressEvent(QMouseEvent *e);
 };
 
 #endif

--- a/headers/mindmapview.h
+++ b/headers/mindmapview.h
@@ -16,13 +16,32 @@ public:
     QGraphicsScene* mindmapScene;
     MainWindow* mainWindow;
 
+    void adjustScale(int ratio){
+        qreal x,y;
+        x = ratio/currentScale;
+        y = ratio/currentScale;
+        scale(x,y);
+        currentScale = ratio;
+    }
+
+    double getCurrentScale(){
+        return currentScale;
+    }
+
+signals:
+    void zoomSignal();
+
 public slots:
 
     void zoomIn(){
-        scale(1.2,1.2);
+        scale(1.25,1.25);
+        currentScale *=1.25;
+        emit zoomSignal();
     }
     void zoomOut(){
         scale(0.8,0.8);
+        currentScale *=0.8;
+        emit zoomSignal();
     }
 
     void focusIn();
@@ -38,6 +57,9 @@ protected:
     }
     void mousePressEvent(QMouseEvent *e);
     void keyPressEvent(QKeyEvent *e);
+
+private:
+    double currentScale;
 };
 
 #endif

--- a/headers/mindmapview.h
+++ b/headers/mindmapview.h
@@ -25,14 +25,19 @@ public slots:
         scale(0.8,0.8);
     }
 
+    void focusIn();
+
 signals:
     void viewClicked();
+    void undid();
+    void redid();
 
 protected:
     void wheelEvent(QWheelEvent *event){
         event->delta() > 0 ? zoomIn() : zoomOut();
     }
     void mousePressEvent(QMouseEvent *e);
+    void keyPressEvent(QKeyEvent *e);
 };
 
 #endif

--- a/headers/mindmapview.h
+++ b/headers/mindmapview.h
@@ -13,6 +13,7 @@ public:
     MindmapView(){
         mindmapScene = new QGraphicsScene();
         this->setScene(mindmapScene);
+        setDragMode(QGraphicsView::ScrollHandDrag);
     }
     QGraphicsScene* mindmapScene;
 public slots:
@@ -24,9 +25,19 @@ public slots:
         scale(0.8,0.8);
     }
 
+signals:
+    void viewClicked();
+
 protected:
     void wheelEvent(QWheelEvent *event){
         event->delta() > 0 ? zoomIn() : zoomOut();
+    }
+    void mousePressEvent(QMouseEvent *e){
+        if(e->button() == Qt::RightButton){
+            this->setFocus();
+            emit viewClicked();
+        }
+        QGraphicsView::mousePressEvent(e);
     }
 };
 

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -15,6 +15,9 @@
 #include <QFont>
 #include <QScrollBar>
 #include <QFocusEvent>
+#include <QDrag>
+#include <QMimeData>
+#include <QDropEvent>
 #include <QDebug>
 #include "headers/parsing.h"
 #include "headers/process.h"
@@ -25,9 +28,17 @@ class NodeWidget;
 class NodeLabel : public QLabel{
     Q_OBJECT
 public:
+    NodeLabel(){
+        setAcceptDrops(true);
+    }
     void mousePressEvent(QMouseEvent *e);
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
+    void mouseMoveEvent(QMouseEvent *e);
+    void dragEnterEvent(QDragEnterEvent *e);
+    void dragLeaveEvent(QDragLeaveEvent *e);
+    void dragMoveEvent(QDragMoveEvent *e);
+    void dropEvent(QDropEvent *e);
     bool isFocus(){return focus;}
     void setNodeShape(int shape){nodeShape = shape;}
     int getNodeShape(){return nodeShape;}
@@ -44,6 +55,7 @@ signals:
     void keyPressed();
     void arrowPressed(int key);
     void redraw();
+    void commanded(NodeWidget*, NodeWidget*, CommandType);
 
 public slots:
     void focusIn();
@@ -54,6 +66,8 @@ private:
     int nodeShape;
     QString nodeTextColor;
     NodeWidget* container_;
+    QColor color;
+    bool dragOver;
 };
 
 class NodeTextEdit : public QTextEdit{
@@ -95,6 +109,9 @@ public:
     NodeLabel* labelPointer(){return &selfWidget;}
     int getIndex(){return index;}
 
+    NodeWidget* takeNode();
+    bool isChildOf(NodeWidget* ptr);
+
     static NodeWidget* searchFocusInNode(NodeWidget* root);
     //2016/11/14일 추가한 함수
 
@@ -112,6 +129,7 @@ public slots:
 
 signals:
     void commanded(NodeWidget*, CommandType);
+    void commanded(NodeWidget*, NodeWidget*, CommandType);
 
 private:
     void init();

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -106,8 +106,8 @@ private:
         childLayout.setMargin(0);
         edit.verticalScrollBar()->close();
         QObject::connect(&edit,SIGNAL(enterPressed()),this,SLOT(textEditToLabel()));
+        QObject::connect(&edit,SIGNAL(enterPressed()),&selfWidget,SLOT(focusIn()));
         QObject::connect(&edit,SIGNAL(focusOut()),this,SLOT(textEditToLabel()));
-        QObject::connect(&edit,SIGNAL(focusOut()),&selfWidget,SLOT(focusOut()));
         QObject::connect(&selfWidget,SIGNAL(doubleClicked()),this,SLOT(labelToTextEdit()));
         QObject::connect(&edit,SIGNAL(textChanged()),this,SLOT(textEditSizeRenew()));
         QObject::connect(&selfWidget,SIGNAL(tabPressed()),this,SLOT(makeDefaultChildNode()));

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -28,12 +28,10 @@ public:
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
     bool isFocus(){return focus;}
-    void setNodeShape(int shape){
-        nodeShape = shape;
-    }
-    int getNodeShape(){
-        return nodeShape;
-    }
+    void setNodeShape(int shape){nodeShape = shape;}
+    int getNodeShape(){return nodeShape;}
+    void setNodeTextColor(QColor col){nodeTextColor=col.name();}
+    QString getNodeTextColor(){return nodeTextColor;}
     NodeWidget* container(){return container_;}
     void setContainer(NodeWidget* container_){this->container_=container_;}
 
@@ -53,6 +51,7 @@ public slots:
 private:
     bool focus = false;
     int nodeShape;
+    QString nodeTextColor;
     NodeWidget* container_;
 };
 

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -61,17 +61,22 @@ public:
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
     QString text();
+    QString lastText();
     QVector<QString>& textVector(){return textVector_;}
     QString labelText();
     void saveText(QString text_){this->text_ = text_;}
     QString getSavedText(){return text_;}
+    void setLastTextVector(){lastTextVector_ = textVector_;}
+
 
 signals:
     void enterPressed();
     void focusOut();
+    void escPressed();
 
 private:
     QVector<QString> textVector_;
+    QVector<QString> lastTextVector_;
     QString text_;
 };
 
@@ -105,6 +110,7 @@ public slots:
     void makeDefaultSiblingNode();
     void deleteThisNode();
     void focusMoveByArrow(int key);
+    void closeTextEdit();
 
 private:
     void init(){
@@ -113,7 +119,7 @@ private:
         this->setStyleSheet("background-color: transparent");
         //selfWidget.setStyleSheet("background-color: transparent ; border-bottom: 1px solid black;");
         selfWidget.setStyleSheet("border: 2px solid gray;");
-        //selfWidget.setSizePolicy(QSizePolicy::QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
+        selfWidget.setSizePolicy(QSizePolicy::QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
         layout.addWidget(&selfWidget);
         layout.addWidget(&childWidget);
         layout.setSpacing(30);
@@ -133,6 +139,8 @@ private:
         QObject::connect(&selfWidget,SIGNAL(keyPressed()),this,SLOT(labelToTextEdit()));
         QObject::connect(&selfWidget,SIGNAL(arrowPressed(int)),this,SLOT(focusMoveByArrow(int)));
         QObject::connect(&selfWidget,SIGNAL(redraw()),getRoot(),SLOT(update()));
+        QObject::connect(&edit,SIGNAL(escPressed()),this,SLOT(closeTextEdit()));
+        QObject::connect(&edit,SIGNAL(escPressed()),&selfWidget,SLOT(focusIn()));
     }
 
     QFont font;

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -27,6 +27,12 @@ public:
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
     bool isFocus(){return focus;}
+    void setNodeShape(int shape){
+        nodeShape = shape;
+    }
+    int getNodeShape(){
+        return nodeShape;
+    }
 
 signals:
     void doubleClicked();
@@ -43,6 +49,7 @@ public slots:
 
 private:
     bool focus = false;
+    int nodeShape;
 };
 
 class NodeTextEdit : public QTextEdit{
@@ -82,7 +89,9 @@ public:
     NodeTextEdit& getEdit(){return edit;}
     NodeLabel& label(){return selfWidget;}
 
-    static NodeWidget* searchFocusInNode(NodeWidget* root);
+    static NodeLabel* searchFocusInNode(NodeWidget* root);
+    //2016/11/14일 추가한 함수
+
 
 public slots:
     void labelToTextEdit();
@@ -99,7 +108,7 @@ private:
         this->setStyleSheet("background-color: transparent");
         //selfWidget.setStyleSheet("background-color: transparent ; border-bottom: 1px solid black;");
         selfWidget.setStyleSheet("border: 2px solid gray;");
-        selfWidget.setSizePolicy(QSizePolicy::QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
+        //selfWidget.setSizePolicy(QSizePolicy::QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
         layout.addWidget(&selfWidget);
         layout.addWidget(&childWidget);
         layout.setSpacing(30);

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -23,7 +23,6 @@ class MainWindow;
 class NodeLabel : public QLabel{
     Q_OBJECT
 public:
-    void mouseDoubleClickEvent(QMouseEvent *e);
     void mousePressEvent(QMouseEvent *e);
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
@@ -84,7 +83,7 @@ public:
 
 public slots:
     void labelToTextEdit();
-    void textEditToLabal();
+    void textEditToLabel();
     void textEditSizeRenew();
     void makeDefaultChildNode();
     void makeDefaultSiblingNode();
@@ -106,8 +105,9 @@ private:
         layout.setContentsMargins(0,0,0,0);
         childLayout.setMargin(0);
         edit.verticalScrollBar()->close();
-        QObject::connect(&edit,SIGNAL(enterPressed()),this,SLOT(textEditToLabal()));
-        QObject::connect(&edit,SIGNAL(focusOut()),this,SLOT(textEditToLabal()));
+        QObject::connect(&edit,SIGNAL(enterPressed()),this,SLOT(textEditToLabel()));
+        QObject::connect(&edit,SIGNAL(focusOut()),this,SLOT(textEditToLabel()));
+        QObject::connect(&edit,SIGNAL(focusOut()),&selfWidget,SLOT(focusOut()));
         QObject::connect(&selfWidget,SIGNAL(doubleClicked()),this,SLOT(labelToTextEdit()));
         QObject::connect(&edit,SIGNAL(textChanged()),this,SLOT(textEditSizeRenew()));
         QObject::connect(&selfWidget,SIGNAL(tabPressed()),this,SLOT(makeDefaultChildNode()));

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -17,6 +17,7 @@
 #include <QFocusEvent>
 #include <QDebug>
 #include "headers/parsing.h"
+#include "headers/process.h"
 
 class MainWindow;
 class NodeWidget;
@@ -60,14 +61,10 @@ class NodeTextEdit : public QTextEdit{
 public:
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
-    QString text();
-    QString lastText();
     QVector<QString>& textVector(){return textVector_;}
     QString labelText();
     void saveText(QString text_){this->text_ = text_;}
     QString getSavedText(){return text_;}
-    void setLastTextVector(){lastTextVector_ = textVector_;}
-
 
 signals:
     void enterPressed();
@@ -76,7 +73,6 @@ signals:
 
 private:
     QVector<QString> textVector_;
-    QVector<QString> lastTextVector_;
     QString text_;
 };
 
@@ -97,51 +93,28 @@ public:
     NodeTextEdit& getEdit(){return edit;}
     NodeLabel& label(){return selfWidget;}
     NodeLabel* labelPointer(){return &selfWidget;}
+    int getIndex(){return index;}
 
     static NodeWidget* searchFocusInNode(NodeWidget* root);
     //2016/11/14일 추가한 함수
-
 
 public slots:
     void labelToTextEdit();
     void textEditToLabel();
     void textEditSizeRenew();
+    void labelSizeRenew();
     void makeDefaultChildNode();
     void makeDefaultSiblingNode();
-    void deleteThisNode();
+    void deleteFromMap();
+    void disconnectUpperNode();
     void focusMoveByArrow(int key);
     void closeTextEdit();
 
+signals:
+    void commanded(NodeWidget*, CommandType);
+
 private:
-    void init(){
-        fm = new QFontMetrics(edit.currentFont());
-        selfWidget.setContainer(this);
-        this->setStyleSheet("background-color: transparent");
-        //selfWidget.setStyleSheet("background-color: transparent ; border-bottom: 1px solid black;");
-        selfWidget.setStyleSheet("border: 2px solid gray;");
-        selfWidget.setSizePolicy(QSizePolicy::QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
-        layout.addWidget(&selfWidget);
-        layout.addWidget(&childWidget);
-        layout.setSpacing(30);
-        this->setLayout(&layout);
-        childWidget.setLayout(&childLayout);
-        layout.setContentsMargins(0,0,0,0);
-        childLayout.setMargin(0);
-        edit.verticalScrollBar()->close();
-        QObject::connect(&edit,SIGNAL(enterPressed()),this,SLOT(textEditToLabel()));
-        QObject::connect(&edit,SIGNAL(enterPressed()),&selfWidget,SLOT(focusIn()));
-        QObject::connect(&edit,SIGNAL(focusOut()),this,SLOT(textEditToLabel()));
-        QObject::connect(&selfWidget,SIGNAL(doubleClicked()),this,SLOT(labelToTextEdit()));
-        QObject::connect(&edit,SIGNAL(textChanged()),this,SLOT(textEditSizeRenew()));
-        QObject::connect(&selfWidget,SIGNAL(tabPressed()),this,SLOT(makeDefaultChildNode()));
-        QObject::connect(&selfWidget,SIGNAL(enterPressed()),this,SLOT(makeDefaultSiblingNode()));
-        QObject::connect(&selfWidget,SIGNAL(deletePressed()),this,SLOT(deleteThisNode()));
-        QObject::connect(&selfWidget,SIGNAL(keyPressed()),this,SLOT(labelToTextEdit()));
-        QObject::connect(&selfWidget,SIGNAL(arrowPressed(int)),this,SLOT(focusMoveByArrow(int)));
-        QObject::connect(&selfWidget,SIGNAL(redraw()),getRoot(),SLOT(update()));
-        QObject::connect(&edit,SIGNAL(escPressed()),this,SLOT(closeTextEdit()));
-        QObject::connect(&edit,SIGNAL(escPressed()),&selfWidget,SLOT(focusIn()));
-    }
+    void init();
 
     QFont font;
     QFontMetrics* fm;
@@ -155,7 +128,8 @@ private:
     bool editMode = false;
     bool clicked = false;
     int index = 0;
-    MainWindow* mainWindow;
+
+    static MainWindow* mainWindow;
 };
 
 

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -1,5 +1,6 @@
 #ifndef NODEWIDGET_H
 #define NODEWIDGET_H
+#include <QApplication>
 #include <QVector>
 #include <QPaintEvent>
 #include <QPainter>
@@ -7,22 +8,92 @@
 #include <QLabel>
 #include <QLayout>
 #include <QQueue>
+#include <QLineEdit>
+#include <QTextEdit>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QFont>
+#include <QScrollBar>
+#include <QFocusEvent>
+#include <QDebug>
 #include "headers/parsing.h"
 
+class MainWindow;
+
+class NodeLabel : public QLabel{
+    Q_OBJECT
+public:
+    void mouseDoubleClickEvent(QMouseEvent *e);
+    void mousePressEvent(QMouseEvent *e);
+    void keyPressEvent(QKeyEvent *e);
+    void focusOutEvent(QFocusEvent *e);
+
+signals:
+    void doubleClicked();
+    void tabPressed();
+    void enterPressed();
+    void deletePressed();
+    void keyPressed();
+    void arrowPressed(int key);
+    void redraw();
+
+public slots:
+    void focusIn();
+    void focusOut();
+
+private:
+    bool isFocus = false;
+};
+
+class NodeTextEdit : public QTextEdit{
+    Q_OBJECT
+public:
+    void keyPressEvent(QKeyEvent *e);
+    void focusOutEvent(QFocusEvent *e);
+    QString text();
+    QVector<QString>& textVector(){return textVector_;}
+    QString labelText();
+    void saveText(QString text_){this->text_ = text_;}
+    QString getSavedText(){return text_;}
+
+signals:
+    void enterPressed();
+    void focusOut();
+
+private:
+    QVector<QString> textVector_;
+    QString text_;
+};
 
 class NodeWidget : public QWidget{
+    Q_OBJECT
 public:
     NodeWidget(QString name = "Default");
-    NodeWidget(QQueue<MdString> list);  //MdString list -> tree structure
+    NodeWidget(QQueue<MdString> list, MainWindow* mainWindow);  //MdString list -> tree structure
     QVector<NodeWidget*>& getChild(){ return child; }
     NodeWidget* getParent(){return parent_;}
+    NodeWidget* getRoot();
     //int getChildNum(childNum)
+    ~NodeWidget();
 
     void add(NodeWidget *subNode);
+    void insert(int index, NodeWidget *subNode);
     void paintEvent(QPaintEvent *e);
+    NodeTextEdit& getEdit(){return edit;}
+    NodeLabel& label(){return selfWidget;}
+
+public slots:
+    void labelToTextEdit();
+    void textEditToLabal();
+    void textEditSizeRenew();
+    void makeDefaultChildNode();
+    void makeDefaultSiblingNode();
+    void deleteThisNode();
+    void focusMoveByArrow(int key);
 
 private:
     void init(){
+        fm = new QFontMetrics(edit.currentFont());
         this->setStyleSheet("background-color: transparent");
         //selfWidget.setStyleSheet("background-color: transparent ; border-bottom: 1px solid black;");
         selfWidget.setStyleSheet("border: 2px solid gray;");
@@ -34,15 +105,32 @@ private:
         childWidget.setLayout(&childLayout);
         layout.setContentsMargins(0,0,0,0);
         childLayout.setMargin(0);
+        edit.verticalScrollBar()->close();
+        QObject::connect(&edit,SIGNAL(enterPressed()),this,SLOT(textEditToLabal()));
+        QObject::connect(&edit,SIGNAL(focusOut()),this,SLOT(textEditToLabal()));
+        QObject::connect(&selfWidget,SIGNAL(doubleClicked()),this,SLOT(labelToTextEdit()));
+        QObject::connect(&edit,SIGNAL(textChanged()),this,SLOT(textEditSizeRenew()));
+        QObject::connect(&selfWidget,SIGNAL(tabPressed()),this,SLOT(makeDefaultChildNode()));
+        QObject::connect(&selfWidget,SIGNAL(enterPressed()),this,SLOT(makeDefaultSiblingNode()));
+        QObject::connect(&selfWidget,SIGNAL(deletePressed()),this,SLOT(deleteThisNode()));
+        QObject::connect(&selfWidget,SIGNAL(keyPressed()),this,SLOT(labelToTextEdit()));
+        QObject::connect(&selfWidget,SIGNAL(arrowPressed(int)),this,SLOT(focusMoveByArrow(int)));
+        QObject::connect(&selfWidget,SIGNAL(redraw()),getRoot(),SLOT(update()));
     }
 
-    QLabel selfWidget;
+    QFont font;
+    QFontMetrics* fm;
+    NodeLabel selfWidget;
+    NodeTextEdit edit;
     QWidget childWidget;
     QHBoxLayout layout;
     QVBoxLayout childLayout;
     NodeWidget* parent_ = nullptr;
     QVector<NodeWidget*> child;
-    int childNum = 0;
+    bool editMode = false;
+    bool clicked = false;
+    int index = 0;
+    MainWindow* mainWindow;
 };
 
 

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -46,6 +46,7 @@ public:
     QString getNodeTextColor(){return nodeTextColor;}
     NodeWidget* container(){return container_;}
     void setContainer(NodeWidget* container_){this->container_=container_;}
+    QColor& getColor(){return color;}
 
 signals:
     void doubleClicked();
@@ -111,6 +112,8 @@ public:
 
     NodeWidget* takeNode();
     bool isChildOf(NodeWidget* ptr);
+
+    void setEditFont(const QFont &);
 
     static NodeWidget* searchFocusInNode(NodeWidget* root);
     //2016/11/14일 추가한 함수

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -92,6 +92,7 @@ public:
     void paintEvent(QPaintEvent *e);
     NodeTextEdit& getEdit(){return edit;}
     NodeLabel& label(){return selfWidget;}
+    NodeLabel* labelPointer(){return &selfWidget;}
 
     static NodeWidget* searchFocusInNode(NodeWidget* root);
     //2016/11/14일 추가한 함수

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -26,6 +26,7 @@ public:
     void mousePressEvent(QMouseEvent *e);
     void keyPressEvent(QKeyEvent *e);
     void focusOutEvent(QFocusEvent *e);
+    bool isFocus(){return focus;}
 
 signals:
     void doubleClicked();
@@ -41,7 +42,7 @@ public slots:
     void focusOut();
 
 private:
-    bool isFocus = false;
+    bool focus = false;
 };
 
 class NodeTextEdit : public QTextEdit{
@@ -80,6 +81,8 @@ public:
     void paintEvent(QPaintEvent *e);
     NodeTextEdit& getEdit(){return edit;}
     NodeLabel& label(){return selfWidget;}
+
+    static NodeWidget* searchFocusInNode(NodeWidget* root);
 
 public slots:
     void labelToTextEdit();

--- a/headers/nodewidget.h
+++ b/headers/nodewidget.h
@@ -19,6 +19,7 @@
 #include "headers/parsing.h"
 
 class MainWindow;
+class NodeWidget;
 
 class NodeLabel : public QLabel{
     Q_OBJECT
@@ -33,6 +34,8 @@ public:
     int getNodeShape(){
         return nodeShape;
     }
+    NodeWidget* container(){return container_;}
+    void setContainer(NodeWidget* container_){this->container_=container_;}
 
 signals:
     void doubleClicked();
@@ -50,6 +53,7 @@ public slots:
 private:
     bool focus = false;
     int nodeShape;
+    NodeWidget* container_;
 };
 
 class NodeTextEdit : public QTextEdit{
@@ -89,7 +93,7 @@ public:
     NodeTextEdit& getEdit(){return edit;}
     NodeLabel& label(){return selfWidget;}
 
-    static NodeLabel* searchFocusInNode(NodeWidget* root);
+    static NodeWidget* searchFocusInNode(NodeWidget* root);
     //2016/11/14일 추가한 함수
 
 
@@ -105,6 +109,7 @@ public slots:
 private:
     void init(){
         fm = new QFontMetrics(edit.currentFont());
+        selfWidget.setContainer(this);
         this->setStyleSheet("background-color: transparent");
         //selfWidget.setStyleSheet("background-color: transparent ; border-bottom: 1px solid black;");
         selfWidget.setStyleSheet("border: 2px solid gray;");

--- a/headers/process.h
+++ b/headers/process.h
@@ -1,0 +1,96 @@
+#ifndef PROCESS_H
+#define PROCESS_H
+
+#include <QObject>
+#include <QVector>
+#include <QString>
+
+class NodeWidget;
+class Command;
+
+enum class CommandType{
+    Text, Add, Delete, Move
+};
+
+class Process : public QObject{
+    Q_OBJECT
+public:
+    ~Process();
+
+public slots:
+    void push(Command*);
+    void undo();
+    void redo();
+
+private:
+    const int STACKSIZE = 50;
+    QVector<Command*> undoStack;
+    QVector<Command*> redoStack;
+};
+
+class Command{
+public:
+    Command(CommandType type_){this->type_=type_;}
+    CommandType tpye(){return type_;}
+    virtual void undo()=0;
+    virtual void redo()=0;
+    virtual NodeWidget* node(){return nullptr;}
+
+protected:
+    CommandType type_;
+};
+
+class TextCommand : public Command{
+public:
+    TextCommand(NodeWidget*);
+    virtual void undo();
+    virtual void redo();
+
+private:
+    NodeWidget* textChangedNode;
+    QString lastText;
+    QString text;
+
+};
+
+class AddCommand : public Command{//redo->delete
+public:
+    AddCommand(NodeWidget*);
+    virtual void undo();
+    virtual void redo();
+    virtual NodeWidget* node(){return addedNode;}
+
+private:
+    NodeWidget* parent_;
+    NodeWidget* addedNode;
+    int index;
+};
+
+class DeleteCommand : public Command{//undo->delete
+public:
+    DeleteCommand(NodeWidget*);
+    virtual void undo();
+    virtual void redo();
+    virtual NodeWidget* node(){return deletedNode;}
+
+private:
+    NodeWidget* parent_;
+    NodeWidget* deletedNode;
+    int index;
+};
+
+class MoveCommand : public Command{
+public:
+    MoveCommand(NodeWidget*);
+    virtual void undo();
+    virtual void redo();
+
+private:
+    NodeWidget* from;
+    NodeWidget* to;
+    NodeWidget* movedNode;
+    int fromIndex;
+    int toIndex;
+};
+
+#endif // PROCESS_H

--- a/headers/process.h
+++ b/headers/process.h
@@ -81,7 +81,7 @@ private:
 
 class MoveCommand : public Command{
 public:
-    MoveCommand(NodeWidget*);
+    MoveCommand(NodeWidget*, NodeWidget*);
     virtual void undo();
     virtual void redo();
 

--- a/pmind.pro
+++ b/pmind.pro
@@ -18,14 +18,16 @@ SOURCES += \
     sources/parsing.cpp \
     sources/nodewidget.cpp \
     forms/propertytab.cpp \
-    sources/mindmapview.cpp
+    sources/mindmapview.cpp \
+    sources/process.cpp
 
 HEADERS  += \
     headers/mainwindow.h \
     headers/parsing.h \
     headers/mindmapview.h \
     headers/nodewidget.h \
-    forms/propertytab.h
+    forms/propertytab.h \
+    headers/process.h
 
 FORMS    += \
     forms/mainwindow.ui \

--- a/pmind.pro
+++ b/pmind.pro
@@ -17,7 +17,8 @@ SOURCES += \
     sources/mainwindow.cpp \
     sources/parsing.cpp \
     sources/nodewidget.cpp \
-    forms/propertytab.cpp
+    forms/propertytab.cpp \
+    sources/mindmapview.cpp
 
 HEADERS  += \
     headers/mainwindow.h \

--- a/pmind.pro
+++ b/pmind.pro
@@ -16,16 +16,19 @@ SOURCES += \
     sources/main.cpp \
     sources/mainwindow.cpp \
     sources/parsing.cpp \
-    sources/nodewidget.cpp
+    sources/nodewidget.cpp \
+    forms/propertytab.cpp
 
 HEADERS  += \
     headers/mainwindow.h \
     headers/parsing.h \
     headers/mindmapview.h \
-    headers/nodewidget.h
+    headers/nodewidget.h \
+    forms/propertytab.h
 
 FORMS    += \
-    forms/mainwindow.ui
+    forms/mainwindow.ui \
+    forms/propertytab.ui
 
 RESOURCES += \
     resources/image.qrc

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -6,8 +6,6 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     MainWindow w;
     w.show();
-
-
     return a.exec();
 }
 

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -31,8 +31,9 @@ MainWindow::MainWindow(QWidget *parent) :
     scaleComboLayout->addWidget(percentLabel);
     scaleComboLayout->addStretch();
 
-    rightLayout->addWidget(dockWidget);
-    rightLayout->addWidget(redrawButton);
+    //rightLayout->addWidget(dockWidget);
+    addDockWidget(Qt::RightDockWidgetArea,dockWidget);
+    //rightLayout->addWidget(redrawButton);
 
     programLayout->addWidget(mapScreen);
     programLayout->addLayout(rightLayout);
@@ -40,7 +41,8 @@ MainWindow::MainWindow(QWidget *parent) :
     programLayout->setStretchFactor(rightLayout,3);
 
     layout->addLayout(scaleComboLayout);
-    layout->addLayout(programLayout);
+    //layout->addLayout(programLayout);
+    layout->addWidget(mapScreen);
 
     QObject::connect(mapScreen,SIGNAL(undid()),process,SLOT(undo()));
     QObject::connect(mapScreen,SIGNAL(redid()),process,SLOT(redo()));

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -11,7 +11,7 @@ MainWindow::MainWindow(QWidget *parent) :
     // construct & set UI component
     mapScreen = new MindmapView();
     dockWidget = new PropertyTab(this);
-    edit = new QTextEdit();
+    edit = dockWidget->getTextEdit();
     redrawButton = new QPushButton("Redraw");
     layout = new QVBoxLayout();
     programLayout = new QHBoxLayout();

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -177,8 +177,13 @@ void MainWindow::addProcess(NodeWidget* node, CommandType type){
     case CommandType::Text:
         process->push(new TextCommand(node));
         break;
-//    case CommandType::Move:
-//        process->push(new MoveCommand(node));
-//        break;
+    }
+}
+
+void MainWindow::addProcess(NodeWidget *movedNode, NodeWidget *to, CommandType type){
+    switch(type){
+    case CommandType::Move:
+        process->push(new MoveCommand(movedNode, to));
+        break;
     }
 }

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -16,6 +16,7 @@ MainWindow::MainWindow(QWidget *parent) :
     layout = new QHBoxLayout();
     rightLayout = new QVBoxLayout();
     map = nullptr;
+    process = new Process;
 
     rightLayout->addWidget(dockWidget);
     rightLayout->addWidget(redrawButton);
@@ -24,12 +25,15 @@ MainWindow::MainWindow(QWidget *parent) :
     layout->setStretchFactor(mapScreen,7);
     layout->setStretchFactor(rightLayout,3);
 
+    QObject::connect(mapScreen,SIGNAL(undid()),process,SLOT(undo()));
+    QObject::connect(mapScreen,SIGNAL(redid()),process,SLOT(redo()));
     mapScreen->setStyleSheet("MindmapView {border: 1px solid gray; background: white;}");
     this->centralWidget()->setLayout(layout);
 
     mapScreen->mainWindow = this;
 
     QObject::connect(redrawButton, SIGNAL(clicked()),this,SLOT(reload()));
+
 }
 
 MainWindow::~MainWindow()
@@ -44,6 +48,7 @@ MainWindow::~MainWindow()
     }
     delete mapScreen;
     delete layout;
+    //delete process;
 }
 
 //re-allocate & re-draw mindmap
@@ -159,4 +164,21 @@ void MainWindow::setFileMenuToolbar() {
     connect(actionSave, SIGNAL(triggered()), this, SLOT(saveFile()));
     connect(actionSaveAs, SIGNAL(triggered()), this, SLOT(saveFileAs()));
     connect(actionQuit, SIGNAL(triggered()), this, SLOT(quit()));
+}
+
+void MainWindow::addProcess(NodeWidget* node, CommandType type){
+    switch(type){
+    case CommandType::Add:
+        process->push(new AddCommand(node));
+        break;
+    case CommandType::Delete:
+        process->push(new DeleteCommand(node));
+        break;
+    case CommandType::Text:
+        process->push(new TextCommand(node));
+        break;
+//    case CommandType::Move:
+//        process->push(new MoveCommand(node));
+//        break;
+    }
 }

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -8,7 +8,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     setFileMenuToolbar();
     setWindowTitle("P-mind");
-
     // construct & set UI component
     mapScreen = new MindmapView();
     edit = new QTextEdit();
@@ -46,17 +45,22 @@ MainWindow::~MainWindow()
 
 //re-allocate & re-draw mindmap
 void MainWindow::reload(){
-    if (map!=nullptr){
+   if (map!=nullptr){
+        QObject::disconnect(mapScreen,SIGNAL(viewClicked()),map,SLOT(update()));
         delete map;
         map = nullptr;
     }
     QString str = edit->toPlainText();
     QQueue<MdString> q;
     getQqueue(str,q);
-    map = new NodeWidget(q);
+    map = new NodeWidget(q, this);
     mapScreen->mindmapScene->addWidget(map);
+    QObject::connect(mapScreen,SIGNAL(viewClicked()),map,SLOT(update()));
 }
 
+void MainWindow::renewTextEdit(){
+
+}
 
 void MainWindow::newFile(){
     m_fileName = "NewFile"; //use default file name

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -27,6 +27,8 @@ MainWindow::MainWindow(QWidget *parent) :
     mapScreen->setStyleSheet("MindmapView {border: 1px solid gray; background: white;}");
     this->centralWidget()->setLayout(layout);
 
+    mapScreen->mainWindow = this;
+
     QObject::connect(redrawButton, SIGNAL(clicked()),this,SLOT(reload()));
 }
 

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -10,13 +10,14 @@ MainWindow::MainWindow(QWidget *parent) :
     setWindowTitle("P-mind");
     // construct & set UI component
     mapScreen = new MindmapView();
+    dockWidget = new PropertyTab(this);
     edit = new QTextEdit();
     redrawButton = new QPushButton("Redraw");
     layout = new QHBoxLayout();
     rightLayout = new QVBoxLayout();
     map = nullptr;
 
-    rightLayout->addWidget(edit);
+    rightLayout->addWidget(dockWidget);
     rightLayout->addWidget(redrawButton);
     layout->addWidget(mapScreen);
     layout->addLayout(rightLayout);
@@ -56,6 +57,7 @@ void MainWindow::reload(){
     map = new NodeWidget(q, this);
     mapScreen->mindmapScene->addWidget(map);
     QObject::connect(mapScreen,SIGNAL(viewClicked()),map,SLOT(update()));
+    dockWidget->setNodeWidget(map);
 }
 
 void MainWindow::renewTextEdit(){

--- a/sources/mindmapview.cpp
+++ b/sources/mindmapview.cpp
@@ -1,0 +1,20 @@
+#include "headers/mindmapview.h"
+#include "headers/mainwindow.h"
+
+MindmapView::MindmapView(){
+    mindmapScene = new QGraphicsScene();
+    this->setScene(mindmapScene);
+    setDragMode(QGraphicsView::ScrollHandDrag);
+}
+
+void MindmapView::mousePressEvent(QMouseEvent *e){
+
+    NodeWidget* temp;
+    temp = NodeWidget::searchFocusInNode(mainWindow->getMap());
+    if(temp != nullptr)
+        temp->label().focusOut();
+    this->setFocus();
+    emit viewClicked();
+
+    QGraphicsView::mousePressEvent(e);
+}

--- a/sources/mindmapview.cpp
+++ b/sources/mindmapview.cpp
@@ -4,6 +4,7 @@ MindmapView::MindmapView(){
     mindmapScene = new QGraphicsScene();
     this->setScene(mindmapScene);
     setDragMode(QGraphicsView::ScrollHandDrag);
+    currentScale = 100;
 }
 
 void MindmapView::mousePressEvent(QMouseEvent *e){

--- a/sources/mindmapview.cpp
+++ b/sources/mindmapview.cpp
@@ -1,4 +1,3 @@
-#include "headers/mindmapview.h"
 #include "headers/mainwindow.h"
 
 MindmapView::MindmapView(){
@@ -8,13 +7,37 @@ MindmapView::MindmapView(){
 }
 
 void MindmapView::mousePressEvent(QMouseEvent *e){
+    focusIn();
+    emit viewClicked();
 
+    QGraphicsView::mousePressEvent(e);
+}
+
+void MindmapView::keyPressEvent(QKeyEvent *e){
+    switch(e->key()){
+    case Qt::Key_Z:
+        if(e->modifiers().testFlag(Qt::ControlModifier))
+            emit undid();
+        else
+            QGraphicsView::keyPressEvent(e);
+
+        break;
+    case Qt::Key_Y:
+        if(e->modifiers().testFlag(Qt::ControlModifier))
+            emit redid();
+        else
+            QGraphicsView::keyPressEvent(e);
+        break;
+    default:
+        QGraphicsView::keyPressEvent(e);
+        break;
+    }
+}
+
+void MindmapView::focusIn(){
     NodeWidget* temp;
     temp = NodeWidget::searchFocusInNode(mainWindow->getMap());
     if(temp != nullptr)
         temp->label().focusOut();
     this->setFocus();
-    emit viewClicked();
-
-    QGraphicsView::mousePressEvent(e);
 }

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -1,10 +1,6 @@
 #include "headers/nodewidget.h"
 #include "headers/mainwindow.h"
 
-void NodeLabel::mouseDoubleClickEvent(QMouseEvent *e){
-    emit doubleClicked();
-}
-
 void NodeLabel::mousePressEvent(QMouseEvent *e){
     if(isFocus){
         emit doubleClicked();
@@ -182,10 +178,9 @@ void NodeWidget::labelToTextEdit(){
     delete layout.takeAt(0);
     layout.insertWidget(0,&edit);
     edit.show();
-    edit.setFocus();
 }
 
-void NodeWidget::textEditToLabal(){
+void NodeWidget::textEditToLabel(){
     if(editMode){
       editMode = false;
       selfWidget.show();

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -54,13 +54,13 @@ void NodeLabel::focusIn(){
         temp->label().focusOut();
     this->setFocus();
     focus = true;
-    this->setStyleSheet("border: 4px solid gray;");
+    //this->setStyleSheet("border: 4px solid gray;");
     emit redraw();
 }
 
 void NodeLabel::focusOut(){
     focus = false;
-    this->setStyleSheet("border: 2px solid gray;");
+    //this->setStyleSheet("border: 2px solid gray;");
     emit redraw();
 }
 

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -1,19 +1,127 @@
 #include "headers/nodewidget.h"
+#include "headers/mainwindow.h"
 
+void NodeLabel::mouseDoubleClickEvent(QMouseEvent *e){
+    emit doubleClicked();
+}
+
+void NodeLabel::mousePressEvent(QMouseEvent *e){
+    if(isFocus){
+        emit doubleClicked();
+    }
+    else{
+        qDebug()<<"setFocus";
+        this->focusIn();
+    }
+}
+
+void NodeLabel::keyPressEvent(QKeyEvent *e){
+    switch(e->key()){
+    case Qt::Key_Tab:
+        emit tabPressed();
+        break;
+    case Qt::Key_Enter:
+        emit enterPressed();
+        break;
+    case Qt::Key_Return:
+        emit enterPressed();
+        break;
+    case Qt::Key_Delete:
+        emit deletePressed();
+        break;
+    case Qt::Key_Left:
+        emit arrowPressed(Qt::Key_Left);
+        break;
+    case Qt::Key_Right:
+        emit arrowPressed(Qt::Key_Right);
+        break;
+    case Qt::Key_Up:
+        emit arrowPressed(Qt::Key_Up);
+        break;
+    case Qt::Key_Down:
+        emit arrowPressed(Qt::Key_Down);
+        break;
+    default:
+        emit keyPressed();
+        QLabel::keyPressEvent(e);
+        break;
+    }
+}
+
+void NodeLabel::focusOutEvent(QFocusEvent *e){
+    this->focusOut();
+    qDebug()<<isFocus<<text();
+}
+
+void NodeLabel::focusIn(){
+    this->setFocus();
+    isFocus = true;
+    this->setStyleSheet("border: 4px solid gray;");
+    emit redraw();
+}
+
+void NodeLabel::focusOut(){
+    isFocus = false;
+    this->setStyleSheet("border: 2px solid gray;");
+    emit redraw();
+}
+
+void NodeTextEdit::keyPressEvent(QKeyEvent *e){
+    if(e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return){
+        if(e->modifiers().testFlag(Qt::ShiftModifier)){
+            QTextEdit::keyPressEvent(e);
+            qDebug() << "shift!!";
+        }
+        else{
+            emit enterPressed();
+            qDebug() << "enter!";
+        }
+    }
+    else if(e->key() == Qt::Key_Tab)
+        qDebug() << text_;
+    else{
+        QTextEdit::keyPressEvent(e);
+    }
+}
+
+void NodeTextEdit::focusOutEvent(QFocusEvent *e){
+    emit focusOut();
+}
+
+QString NodeTextEdit::text(){
+    QString temp = "";
+    for(int i=0;i<textVector_.count();i++)
+        temp += textVector_[i];
+    return temp;
+}
+
+QString NodeTextEdit::labelText(){
+    QString temp = "";
+    for(int i=0;i<textVector_.count()-1;i++){
+        temp += textVector_[i] + "\n";
+    }
+    temp += textVector_.last();
+    return temp;
+}
 
 NodeWidget::NodeWidget(QString name){
     init();
     selfWidget.setText(name);
+    edit.saveText(name);
 }
 
-NodeWidget::NodeWidget(QQueue<MdString> list){
+NodeWidget::NodeWidget(QQueue<MdString> list, MainWindow* mainWindow){
     init();
+    this->mainWindow = mainWindow;
+    QObject::connect(&edit,SIGNAL(enterPressed()),mainWindow,SLOT(renewTextEdit()));
     if(list.isEmpty()){
         selfWidget.setText("ERROR: not valid .md file");
         return;
     }
     else{
-        selfWidget.setText(list.dequeue().getText());
+        QString temp;
+        selfWidget.setText(temp = list.dequeue().getText());
+        edit.saveText(temp);
         NodeWidget* ptr = this;
         int currentDepth = 0;
         while(!list.isEmpty()){
@@ -22,6 +130,7 @@ NodeWidget::NodeWidget(QQueue<MdString> list){
                 MdString tempMdString = list.dequeue();
                 temp = tempMdString.getDepth();
                 NodeWidget* tempnode = new NodeWidget(tempMdString.getText());
+                QObject::connect(&tempnode->getEdit(),SIGNAL(enterPressed()),mainWindow,SLOT(renewTextEdit()));
                 ptr->add(tempnode);
                 ptr = tempnode;
                 currentDepth++;
@@ -32,16 +141,174 @@ NodeWidget::NodeWidget(QQueue<MdString> list){
             }
         }
     }
-
-
 }
 
+NodeWidget* NodeWidget::getRoot(){
+    NodeWidget* temp;
+    temp = this;
+    while(temp->parent_!=nullptr)
+        temp = temp->parent_;
+    return temp;
+}
+
+NodeWidget::~NodeWidget(){
+    int num = child.count();
+    delete fm;
+    for(int i=0;i<num;i++){
+        delete child[i];
+    }
+}
 
 void NodeWidget::add(NodeWidget *subNodeWidget){
     child.push_back(subNodeWidget);
-    childLayout.addWidget(child[childNum]);
-    child[childNum]->parent_ = this;
-    childNum++;
+    childLayout.addWidget(subNodeWidget);
+    subNodeWidget->parent_ = this;
+    subNodeWidget->mainWindow = mainWindow;
+    subNodeWidget->index = child.count()-1;
+}
+
+void NodeWidget::insert(int index, NodeWidget *subNode){
+    child.insert(index, subNode);
+    childLayout.insertWidget(index, subNode);
+    for(int i=index+1;i<child.count();i++)
+        child[i]->index++;
+    subNode->parent_ = this;
+    subNode->mainWindow = mainWindow;
+    subNode->index = index;
+}
+
+void NodeWidget::labelToTextEdit(){
+    editMode = true;
+    edit.setReadOnly(false);
+    edit.setText(edit.getSavedText());
+    textEditSizeRenew();
+    edit.selectAll();
+    selfWidget.hide();
+    delete layout.takeAt(0);
+    layout.insertWidget(0,&edit);
+    edit.show();
+    edit.setFocus();
+}
+
+void NodeWidget::textEditToLabal(){
+    if(editMode){
+      editMode = false;
+      selfWidget.show();
+      selfWidget.focusIn();
+      selfWidget.setText(edit.labelText());
+      delete layout.takeAt(0);
+      layout.insertWidget(0,&selfWidget);
+      edit.setText("");
+      edit.setReadOnly(true);
+      edit.hide();
+    }
+}
+
+void NodeWidget::textEditSizeRenew(){
+    int charCount;
+    int y = 1;
+    QString temp = "";
+    QString text;
+    QStringList spaceSplit;
+    if(editMode){
+        edit.textVector().clear();
+        text = edit.toPlainText();
+        edit.saveText(text);
+        charCount = text.count();
+        for(int i=0;i<charCount;i++){
+            temp += text[i];
+            if(text[i] == '\n'){
+                y++;
+                edit.textVector().append("");
+                for(int i=0;i<temp.count()-1;i++)
+                    edit.textVector()[edit.textVector().count()-1]+=temp[i];
+                temp = "";
+                continue;
+            }
+            if(fm->width(temp) > 100){
+                spaceSplit = temp.split(' ');
+                if(spaceSplit.count() == 1){
+                    edit.textVector().append("");
+                    for(int i=0;i<temp.count()-1;i++)
+                        edit.textVector()[edit.textVector().count()-1]+=temp[i];
+                    temp = temp[temp.count()-1];
+                    y++;
+                }
+                else{
+                    edit.textVector().append("");
+                    for(int i=0;i<spaceSplit.count()-2;i++)
+                        edit.textVector()[edit.textVector().count()-1]+=spaceSplit[i] + " ";
+                    edit.textVector()[edit.textVector().count()-1]+=spaceSplit[spaceSplit.count()-2];
+                    temp = spaceSplit.last();
+                    y++;
+                }
+            }
+        }
+        edit.textVector().append(temp);
+        if(y == 1){
+            edit.setFixedSize(fm->width(temp) + 30, fm->height() + 12);
+            edit.setFixedSize(fm->width(temp) + 10, fm->height() + 12);
+        }
+        else{
+            edit.setFixedSize(130, (fm->height()+2)*y + 10);
+            edit.setFixedSize(110, (fm->height()+2)*y + 10);
+        }
+    }
+}
+
+void NodeWidget::makeDefaultChildNode(){
+    NodeWidget* child = new NodeWidget("default");
+    add(child);
+    child->label().focusIn();
+    selfWidget.focusOut();
+}
+
+void NodeWidget::makeDefaultSiblingNode(){
+    if(parent_!=nullptr){
+        NodeWidget* child = new NodeWidget("default");
+        parent_->insert(index + 1, child);
+        child->label().focusIn();
+        selfWidget.focusOut();
+    }
+}
+
+void NodeWidget::deleteThisNode(){
+    this->~NodeWidget();
+    if(parent_ != nullptr){
+        parent_->child.removeAt(index);
+        for(int i=index;i<parent_->child.count();i++)
+            parent_->child[i]->index--;
+    }
+    getRoot()->update();
+}
+
+void NodeWidget::focusMoveByArrow(int key){
+    switch(key){
+    case Qt::Key_Left:
+        if(parent_!=nullptr){
+            selfWidget.focusOut();
+            parent_->label().focusIn();
+        }
+        break;
+    case Qt::Key_Right:
+        if(child.count()!=0){
+            selfWidget.focusOut();
+            child[0]->label().focusIn();
+        }
+        break;
+    case Qt::Key_Up:
+        if(index!=0){
+            selfWidget.focusOut();
+            parent_->child[index-1]->label().focusIn();
+        }
+        break;
+    case Qt::Key_Down:
+        if(parent_!=nullptr && this!=parent_->child.last()){
+            selfWidget.focusOut();
+            parent_->child[index+1]->label().focusIn();
+        }
+        break;
+    }
 }
 
 void NodeWidget::paintEvent(QPaintEvent *e){
@@ -49,10 +316,11 @@ void NodeWidget::paintEvent(QPaintEvent *e){
     QPen myPen;
     myPen.setWidth(2);
     painter.setPen(myPen);
+    painter.setRenderHint(QPainter::HighQualityAntialiasing);
 
     //painter.drawLine();
     //painter.drawLine(selfWidget.mapToParent(selfWidget.rect().bottomLeft()),selfWidget.mapToParent(selfWidget.rect().bottomRight()));
-    for(int i = 0 ; i<childNum ; i++){
+    for(int i = 0 ; i<child.count() ; i++){
         QPoint temp;
         temp = selfWidget.mapToGlobal(selfWidget.rect().bottomRight());
         QPoint pos1 = this->mapFromGlobal(temp);

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -576,3 +576,12 @@ bool NodeWidget::isChildOf(NodeWidget* ptr){
     else
         return parent_->isChildOf(ptr);
 }
+
+void NodeWidget::setEditFont(const QFont &font){
+    delete fm;
+    fm = new QFontMetrics(font);
+    this->font = font;
+    edit.setFont(font);
+    if(editMode)
+        textEditSizeRenew();
+}

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -2,7 +2,7 @@
 #include "headers/mainwindow.h"
 
 void NodeLabel::mousePressEvent(QMouseEvent *e){
-    if(isFocus){
+    if(focus){
         emit doubleClicked();
     }
     else{
@@ -49,13 +49,13 @@ void NodeLabel::focusOutEvent(QFocusEvent *e){
 
 void NodeLabel::focusIn(){
     this->setFocus();
-    isFocus = true;
+    focus = true;
     this->setStyleSheet("border: 4px solid gray;");
     emit redraw();
 }
 
 void NodeLabel::focusOut(){
-    isFocus = false;
+    focus = false;
     this->setStyleSheet("border: 2px solid gray;");
     emit redraw();
 }
@@ -168,6 +168,31 @@ void NodeWidget::insert(int index, NodeWidget *subNode){
     subNode->index = index;
 }
 
+NodeWidget* NodeWidget::searchFocusInNode(NodeWidget* root){
+    QQueue<NodeWidget*> queue;
+    NodeWidget* temp;
+    int i;
+
+    if(root == nullptr)
+        return nullptr;
+    queue.push_back(root);
+
+    while(!queue.empty()){
+        temp = queue.front();
+        queue.pop_front();
+        if(temp->editMode){
+            return temp;
+        }
+        else{
+            if(temp->selfWidget.isFocus())
+                return temp;
+        }
+        for(i = 0; i<temp->child.count();i++)
+            queue.push_back(temp->child[i]);
+    }
+    return nullptr;
+}
+
 void NodeWidget::labelToTextEdit(){
     editMode = true;
     edit.setReadOnly(false);
@@ -183,14 +208,14 @@ void NodeWidget::labelToTextEdit(){
 
 void NodeWidget::textEditToLabel(){
     if(editMode){
-      editMode = false;
-      selfWidget.show();
-      selfWidget.setText(edit.labelText());
-      delete layout.takeAt(0);
-      layout.insertWidget(0,&selfWidget);
-      edit.setText("");
-      edit.setReadOnly(true);
-      edit.hide();
+        editMode = false;
+        selfWidget.show();
+        selfWidget.setText(edit.labelText());
+        delete layout.takeAt(0);
+        layout.insertWidget(0,&selfWidget);
+        edit.setText("");
+        edit.setReadOnly(true);
+        edit.hide();
     }
 }
 

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -2,7 +2,6 @@
 #include "headers/mainwindow.h"
 
 void NodeLabel::mousePressEvent(QMouseEvent *e){
-    qDebug() << focus;
     if(focus){
         emit doubleClicked();
     }

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -161,7 +161,7 @@ void NodeLabel::dropEvent(QDropEvent *event){
         NodeWidget* temp1 = ((NodeWidget*)parent());
         void* temp = qvariant_cast<void*>(event->mimeData()->colorData());
         NodeWidget* temp2 = (NodeWidget*)temp;
-        if(!(temp1->isChildOf(temp2))){
+        if(!(temp1->isChildOf(temp2) || temp2 == temp2)){
             emit commanded(temp2,temp1,CommandType::Move);
             temp2 = temp2->takeNode();
             temp1->insert(temp1->getChild().size(),temp2);

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -168,7 +168,7 @@ void NodeWidget::insert(int index, NodeWidget *subNode){
     subNode->index = index;
 }
 
-NodeWidget* NodeWidget::searchFocusInNode(NodeWidget* root){
+NodeLabel* NodeWidget::searchFocusInNode(NodeWidget* root){
     QQueue<NodeWidget*> queue;
     NodeWidget* temp;
     int i;
@@ -181,11 +181,11 @@ NodeWidget* NodeWidget::searchFocusInNode(NodeWidget* root){
         temp = queue.front();
         queue.pop_front();
         if(temp->editMode){
-            return temp;
+            return &(temp->selfWidget);
         }
         else{
             if(temp->selfWidget.isFocus())
-                return temp;
+                return &(temp->selfWidget);
         }
         for(i = 0; i<temp->child.count();i++)
             queue.push_back(temp->child[i]);

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -2,6 +2,7 @@
 #include "headers/mainwindow.h"
 
 void NodeLabel::mousePressEvent(QMouseEvent *e){
+    qDebug() << focus;
     if(focus){
         emit doubleClicked();
     }
@@ -44,10 +45,14 @@ void NodeLabel::keyPressEvent(QKeyEvent *e){
 }
 
 void NodeLabel::focusOutEvent(QFocusEvent *e){
-    this->focusOut();
+    //this->focusOut();
 }
 
 void NodeLabel::focusIn(){
+    NodeWidget* temp;
+    temp = NodeWidget::searchFocusInNode(container_->getRoot());
+    if(temp != nullptr)
+        temp->label().focusOut();
     this->setFocus();
     focus = true;
     this->setStyleSheet("border: 4px solid gray;");
@@ -168,7 +173,7 @@ void NodeWidget::insert(int index, NodeWidget *subNode){
     subNode->index = index;
 }
 
-NodeLabel* NodeWidget::searchFocusInNode(NodeWidget* root){
+NodeWidget* NodeWidget::searchFocusInNode(NodeWidget* root){
     QQueue<NodeWidget*> queue;
     NodeWidget* temp;
     int i;
@@ -181,11 +186,11 @@ NodeLabel* NodeWidget::searchFocusInNode(NodeWidget* root){
         temp = queue.front();
         queue.pop_front();
         if(temp->editMode){
-            return &(temp->selfWidget);
+            return temp;
         }
         else{
             if(temp->selfWidget.isFocus())
-                return &(temp->selfWidget);
+                return temp;
         }
         for(i = 0; i<temp->child.count();i++)
             queue.push_back(temp->child[i]);

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -178,13 +178,13 @@ void NodeWidget::labelToTextEdit(){
     delete layout.takeAt(0);
     layout.insertWidget(0,&edit);
     edit.show();
+    edit.setFocus();
 }
 
 void NodeWidget::textEditToLabel(){
     if(editMode){
       editMode = false;
       selfWidget.show();
-      selfWidget.focusIn();
       selfWidget.setText(edit.labelText());
       delete layout.takeAt(0);
       layout.insertWidget(0,&selfWidget);

--- a/sources/nodewidget.cpp
+++ b/sources/nodewidget.cpp
@@ -10,7 +10,6 @@ void NodeLabel::mousePressEvent(QMouseEvent *e){
         emit doubleClicked();
     }
     else{
-        qDebug()<<"setFocus";
         this->focusIn();
     }
 }
@@ -50,7 +49,6 @@ void NodeLabel::keyPressEvent(QKeyEvent *e){
 
 void NodeLabel::focusOutEvent(QFocusEvent *e){
     this->focusOut();
-    qDebug()<<isFocus<<text();
 }
 
 void NodeLabel::focusIn(){
@@ -70,15 +68,12 @@ void NodeTextEdit::keyPressEvent(QKeyEvent *e){
     if(e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return){
         if(e->modifiers().testFlag(Qt::ShiftModifier)){
             QTextEdit::keyPressEvent(e);
-            qDebug() << "shift!!";
         }
         else{
             emit enterPressed();
-            qDebug() << "enter!";
         }
     }
-    else if(e->key() == Qt::Key_Tab)
-        qDebug() << text_;
+    else if(e->key() == Qt::Key_Tab);
     else{
         QTextEdit::keyPressEvent(e);
     }

--- a/sources/process.cpp
+++ b/sources/process.cpp
@@ -1,0 +1,124 @@
+#include "headers/mainwindow.h"
+
+Process::~Process(){
+    while(!undoStack.isEmpty()){
+        if(undoStack.front()->tpye() == CommandType::Delete)
+            delete undoStack.front()->node();
+        delete undoStack.front();
+        undoStack.pop_front();
+    }
+
+    while(!redoStack.isEmpty()){
+        if(redoStack.front()->tpye() == CommandType::Add)
+            delete redoStack.front()->node();
+        delete redoStack.front();
+        redoStack.pop_front();
+    }
+}
+
+void Process::push(Command* command){
+    undoStack.push_back(command);
+
+    if(undoStack.count() > STACKSIZE){
+        if(undoStack.front()->tpye() == CommandType::Delete)
+            delete undoStack.front()->node();
+        delete undoStack.front();
+        undoStack.pop_front();
+    }
+
+    while(!redoStack.isEmpty()){
+        if(redoStack.front()->tpye() == CommandType::Add)
+            delete redoStack.front()->node();
+        delete redoStack.front();
+        redoStack.pop_front();
+    }
+}
+
+void Process::undo(){
+    if(undoStack.count() == 0)
+        return;
+
+    undoStack.last()->undo();
+    redoStack.push_back(undoStack.last());
+
+    if(redoStack.count() > STACKSIZE){
+        if(redoStack.front()->tpye() == CommandType::Add)
+            delete redoStack.front()->node();
+        delete redoStack.front();
+        redoStack.pop_front();
+    }
+    undoStack.pop_back();
+}
+
+void Process::redo(){
+    if(redoStack.count() == 0)
+        return;
+
+    redoStack.last()->redo();
+    undoStack.push_back(redoStack.last());
+    redoStack.pop_back();
+}
+
+TextCommand::TextCommand(NodeWidget* textChangedNode) : Command(CommandType::Text){
+    this->textChangedNode = textChangedNode;
+    lastText = textChangedNode->getEdit().getSavedText();
+    text = textChangedNode->getEdit().toPlainText();
+}
+
+void TextCommand::undo(){
+    textChangedNode->getEdit().saveText(lastText);
+    textChangedNode->labelSizeRenew();
+}
+
+void TextCommand::redo(){
+    textChangedNode->getEdit().saveText(text);
+    textChangedNode->labelSizeRenew();
+}
+
+AddCommand::AddCommand(NodeWidget* addedNode) : Command(CommandType::Add){
+    this->addedNode = addedNode;
+    parent_=addedNode->getParent();
+    index = addedNode->getIndex();
+}
+
+void AddCommand::undo(){
+    addedNode->disconnectUpperNode();
+    addedNode->close();
+    addedNode->label().focusOut();
+}
+
+void AddCommand::redo(){
+    parent_->insert(index, addedNode);
+    addedNode->show();
+}
+
+DeleteCommand::DeleteCommand(NodeWidget* deletedNode) : Command(CommandType::Delete){
+    this->deletedNode = deletedNode;
+    parent_=deletedNode->getParent();
+    index = deletedNode->getIndex();
+}
+
+void DeleteCommand::undo(){
+    parent_->insert(index, deletedNode);
+    deletedNode->show();
+}
+
+void DeleteCommand::redo(){
+    deletedNode->disconnectUpperNode();
+    deletedNode->close();
+    deletedNode->label().focusOut();
+}
+
+void MoveCommand::undo(){
+    movedNode->disconnectUpperNode();
+    movedNode->close();
+    from->insert(fromIndex, movedNode);
+    movedNode->show();
+}
+
+void MoveCommand::redo(){
+    movedNode->disconnectUpperNode();
+    movedNode->close();
+    to->insert(toIndex, movedNode);
+    movedNode->show();
+}

--- a/sources/process.cpp
+++ b/sources/process.cpp
@@ -109,6 +109,14 @@ void DeleteCommand::redo(){
     deletedNode->label().focusOut();
 }
 
+MoveCommand::MoveCommand(NodeWidget *movedNode, NodeWidget *to) : Command(CommandType::Move){
+    this->movedNode = movedNode;
+    this->to = to;
+    from = movedNode->getParent();
+    fromIndex = movedNode->getIndex();
+    toIndex = to->getChild().count();
+}
+
 void MoveCommand::undo(){
     movedNode->disconnectUpperNode();
     movedNode->close();


### PR DESCRIPTION
구현한 기능은 다음과 같습니다.
1. 노드를 클릭하면 focus가 활성화되고 label이 굵어집니다.
2. focus상태인 노드는 keyEvent를 받습니다.
3. focus상태인 노드를 클릭하면 textEdit으로 넘어갑니다.
4. focus상태가 아닌 노드가 double click되어도 textEdit으로 넘어갑니다.
5. focus상태인 노드는 tab(자식노드 추가), enter & return(형제노드 추가), delete(해당 노드와 자식노드 제거) 키를 입력받고 기능을 수행합니다.
6. focus상태인 노드는 arrow key (방향키)를 입력받아 주변의 노드로 focus를 이동시킵니다.
7. focus상태인 노드는 기능키 이외의 입력을 받으면 textEdit으로 넘어갑니다.
8. textEdit는 limit width가 존재하여 두번째 줄 부터는 width가 고정됩니다. 
9. textEdit상태에서 enter를 입력 받으면 label로 돌아갑니다. label은 textEdit와 동일한 형태로 text를 출력합니다.
10. textedit상태에서 shift+enter를 입력 받으면 줄바꿈을 합니다.
11. mouse press and drag로 화면을 이동할 수 있습니다.

Issue
1. 노드를 delete하고 나면 형제 노드간의 간격이 증가하게 됩니다.
2. 노드를 delete하고 나면 곡선이 깨집니다. 이는 mindmap view를 update하여도 마찬가지였습니다.
3. mindmap view가 원점으로 돌아가는 기능이 필요합니다. 노드가 한쪽으로 몰리게 됩니다.
4. textEdit상태에서 line이 증가할 때 곡선이 같이 움직이도록 만들어야 합니다.
5. mindmap view가 focus된 상태에서 tab키를 누르면 마지막으로 focus되었던 노드가 focus됩니다. tab key를 keyEvent에서 비활성화시켜도 해결되지 않습니다.